### PR TITLE
Bump versions to avoid confusion around releases.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type_hash_core"
-version = "0.2.0"
+version = "0.3.1"
 authors = ["Peter Hall <peterjoel@gmail.com"]
 edition = "2018"
 license = "MIT"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type_hash_macros"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Peter Hall <peterjoel@gmail.com"]
 edition = "2018"
 license = "MIT"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -196,6 +196,6 @@ impl<'a> ToTokens for DeriveWhereClause<'a> {
 
 fn split_generics(generics: &Generics) -> (ImplGenerics, TypeGenerics, DeriveWhereClause<'_>) {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let where_clause = DeriveWhereClause(&generics, where_clause);
+    let where_clause = DeriveWhereClause(generics, where_clause);
     (impl_generics, ty_generics, where_clause)
 }

--- a/type_hash/Cargo.toml
+++ b/type_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type_hash"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Peter Hall <peterjoel@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -20,5 +20,5 @@ keywords = ["type", "struct", "hash", "macro"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-type_hash_core = { version = "=0.2.0", path = "../core" }
-type_hash_macros = { version = "=0.3.0", path = "../macros" }
+type_hash_core = { version = "=0.3.1", path = "../core" }
+type_hash_macros = { version = "=0.3.1", path = "../macros" }


### PR DESCRIPTION
`cargo vendor` has issues with the current type_hash dependencies.

The git repository for v0.3.0 contains a version of type_hash_core labelled v0.2 but this is slightly different (e.g. in repository labels) than the v0.2 checked into crates.io.

`cargo vendor` is pulling v0.2 from crates.io rather than using the `path = "../core"` version included in the repo and specified in `type_hash/Cargo.toml` which means it is also dropping the repository label on vendored crates but not when the crate is unvendored.

I'm unclear on the correct semantics here for `cargo vendor`. This change just bumps all versions to circumvent any issues. It'll require a new release to be pushed to crates.io as well.